### PR TITLE
Minor Config Updates

### DIFF
--- a/pyfarm/core/config.py
+++ b/pyfarm/core/config.py
@@ -42,6 +42,8 @@ try:
 except ImportError:  # pragma: no cover
     from io import StringIO
 
+from pkg_resources import DistributionNotFound, get_distribution
+
 import yaml
 try:
     from yaml.loader import CLoader as Loader
@@ -328,8 +330,12 @@ class Configuration(dict):
     :var string DEFAULT_ENVIRONMENT_PATH_VARIABLE:
         A environment variable to search for a configuration path in.
 
-    :param string service_name:
-        The name of the service itself, typically 'master' or 'agent'.
+    :param string name:
+        The name of the configuration itself, typically 'master' or
+        'agent'.  This may also be the name of a package such
+        as 'pyfarm.agent'.  When the package name is provided
+        we can usually automatically determine the version
+        number.
 
     :param string version:
         The version the version of the program running.
@@ -353,15 +359,33 @@ class Configuration(dict):
     DEFAULT_PARENT_APPLICATION_NAME = "pyfarm"
     DEFAULT_ENVIRONMENT_PATH_VARIABLE = "PYFARM_CONFIG_ROOT"
 
-    def __init__(self, service_name, version):
+    def __init__(self, name, version=None):
         super(Configuration, self).__init__()
-        self.service_name = service_name
-        self.version = version
+
+        # If `name` is an import name and an
+        # explict version was not provided then try
+        # to find one automatically.
+        if version is None:
+            try:
+                self.distribution = get_distribution(name)
+
+            except DistributionNotFound:
+                raise ValueError(
+                    "%r is not a Python package so you must provide "
+                    "a version." % name)
+            else:
+                self.version = self.distribution.version
+                self.name = name.split(".")[-1]
+        else:
+            self.distribution = None
+            self.version = version
+            self.name = name
+
         self.file_extension = self.DEFAULT_FILE_EXTENSION
         self.system_root = self.DEFAULT_SYSTEM_ROOT
         self.user_root = self.DEFAULT_USER_ROOT
         self.child_dir = join(
-            self.DEFAULT_PARENT_APPLICATION_NAME, self.service_name)
+            self.DEFAULT_PARENT_APPLICATION_NAME, self.name)
         self.environment_root = read_env(
             self.DEFAULT_ENVIRONMENT_PATH_VARIABLE, None)
         self.local_dir = self.DEFAULT_LOCAL_DIRECTORY_NAME
@@ -371,7 +395,7 @@ class Configuration(dict):
         Splits ``self.version`` into a tuple of individual versions.  For
         example ``1.2.3`` would be split into ``['1', '1.2', '1.2.3']``
         """
-        if self.version is None:
+        if not self.version:
             return []
 
         split = self.version.split(sep)
@@ -427,7 +451,7 @@ class Configuration(dict):
             logger.error("No configuration directories found.")
             return []
 
-        filename = self.service_name + self.file_extension
+        filename = self.name + self.file_extension
         existing_files = []
 
         for directory in directories:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,8 @@ import uuid
 from textwrap import dedent
 from os.path import join, dirname, expandvars, expanduser
 
+from pkg_resources import get_distribution
+
 from pyfarm.core.enums import PY26, LINUX, MAC, WINDOWS
 from pyfarm.core.testutil import TestCase as BaseTestCase, requires_ci
 
@@ -177,12 +179,12 @@ class TestConfiguration(BaseTestCase):
     def test_instance_attributes(self):
         config = Configuration("agent", "1.2.3")
         self.assertIsNotNone(config.DEFAULT_SYSTEM_ROOT)
-        self.assertEqual(config.service_name, "agent")
+        self.assertEqual(config.name, "agent")
         self.assertEqual(config.version, "1.2.3")
         self.assertEqual(config.system_root, Configuration.DEFAULT_SYSTEM_ROOT)
         self.assertEqual(
             config.child_dir,
-            join(config.DEFAULT_PARENT_APPLICATION_NAME, config.service_name))
+            join(config.DEFAULT_PARENT_APPLICATION_NAME, config.name))
         self.assertEqual(config.DEFAULT_FILE_EXTENSION, config.file_extension)
         if config.DEFAULT_ENVIRONMENT_PATH_VARIABLE not in os.environ:
             self.assertIsNone(config.environment_root)
@@ -197,14 +199,14 @@ class TestConfiguration(BaseTestCase):
         self.assertEqual(config.split_version(), ["1", "1.2", "1.2.3"])
 
     def test_split_empty_version(self):
-        config = Configuration("agent", None)
+        config = Configuration("agent", "")
         self.assertEqual(config.split_version(), [])
 
     @requires_ci  # this test modifies the system and should not run elsewhere
     def test_files_system_root(self):
         config = Configuration("agent", "1.2.3")
         split = config.split_version()
-        filename = config.service_name + config.file_extension
+        filename = config.name + config.file_extension
         all_paths = [
             join(config.system_root, config.child_dir + os.sep, filename),
             join(config.system_root, config.child_dir, split[0], filename),
@@ -238,7 +240,7 @@ class TestConfiguration(BaseTestCase):
         config.system_root = local_root
         self.add_cleanup_path(local_root)
         split = config.split_version()
-        filename = config.service_name + config.file_extension
+        filename = config.name + config.file_extension
         paths = [
             join(config.system_root, config.child_dir + os.sep, filename),
             join(config.system_root, config.child_dir, split[2], filename)]
@@ -264,7 +266,7 @@ class TestConfiguration(BaseTestCase):
         config.system_root = local_root
         self.add_cleanup_path(local_root)
         split = config.split_version()
-        filename = config.service_name + config.file_extension
+        filename = config.name + config.file_extension
         paths = [
             join(config.system_root, config.child_dir + os.sep, filename),
             join(config.system_root, config.child_dir, split[2], filename)]
@@ -288,7 +290,7 @@ class TestConfiguration(BaseTestCase):
         config.system_root = local_root
         self.add_cleanup_path(local_root)
         split = config.split_version()
-        filename = config.service_name + config.file_extension
+        filename = config.name + config.file_extension
         paths = [
             join(config.system_root, config.child_dir + os.sep, filename),
             join(config.system_root, config.child_dir, split[2], filename)]
@@ -311,7 +313,7 @@ class TestConfiguration(BaseTestCase):
         config.system_root = local_root
         self.add_cleanup_path(local_root)
         split = config.split_version()
-        filename = config.service_name + config.file_extension
+        filename = config.name + config.file_extension
         paths = [
             join(config.system_root, config.child_dir + os.sep, filename),
             join(config.system_root, config.child_dir, split[2], filename)]
@@ -335,3 +337,14 @@ class TestConfiguration(BaseTestCase):
         environment = {}
         config.load(environment=environment)
         self.assertEqual(environment, {"key0": 0, "key1": 1, "key": 1})
+
+    def test_auto_version(self):
+        distro = get_distribution("pyfarm.core")
+        config = Configuration("pyfarm.core")
+        self.assertEqual(config.distribution, distro)
+        self.assertEqual(config.version, distro.version)
+        self.assertEqual(config.name, "core")
+
+    def test_auto_version_fail(self):
+        with self.assertRaises(ValueError):
+            Configuration("foobar")


### PR DESCRIPTION
After looking at using this on the agent side I've come up with a couple of small changes:
- Empty configurations raised exceptions
- We can auto-determine the version number based on the installed package.
- `service_name` is more appropriately named `name`
