### PR TITLE
Reverse the order in which config files are loaded

### DIFF
--- a/pyfarm/core/config.py
+++ b/pyfarm/core/config.py
@@ -498,21 +498,24 @@ class Configuration(dict):
 
         versions.append("")  # the 'version free' directory
 
-        # If provided, append the root discovered in the environment
-        if self.environment_root is not None:
-            roots.append(join(self.environment_root, self.child_dir))
+        # If provided, insert the default root
+        if self.system_root:  # could be empty in the environment
+            roots.append(join(self.system_root, self.child_dir))
+
+        # If provided, append the user directory
+        if self.user_root:  # could be empty in the environment
+            if not WINDOWS:
+                roots.append(join(self.user_root, "." + self.child_dir))
+            else:
+                roots.append(join(self.user_root, self.child_dir))
 
         # If provided append a local directory
         if self.local_dir is not None:
             roots.append(join(self.local_dir, self.child_dir))
 
-        # If provided, append the user directory
-        if self.user_root:  # could be empty in the environment
-            roots.append(join(self.user_root, "." + self.child_dir))
-
-        # If provided, insert the default root
-        if self.system_root:  # could be empty in the environment
-            roots.append(join(self.system_root, self.child_dir))
+        # If provided, append the root discovered in the environment
+        if self.environment_root is not None:
+            roots.append(join(self.environment_root, self.child_dir))
 
         all_directories = []
         existing_directories = []
@@ -549,12 +552,6 @@ class Configuration(dict):
         filename = self.name + self.file_extension
         existing_files = []
 
-        for directory in directories:
-            filepath = join(directory, filename)
-
-            if not validate or isfile(filepath):
-                existing_files.append(filepath)
-
         if self.package_configuration is not None:
             if not validate or isfile(self.package_configuration):
                 existing_files.append(self.package_configuration)
@@ -564,6 +561,12 @@ class Configuration(dict):
                     "%r does not have a default configuration file. Expected "
                     "to find %r but this path does not exist.",
                     self._name, self.package_configuration)
+
+        for directory in directories:
+            filepath = join(directory, filename)
+
+            if not validate or isfile(filepath):
+                existing_files.append(filepath)
 
         if not existing_files:  # pragma: no cover
             logger.error(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -213,22 +213,22 @@ class TestConfiguration(BaseTestCase):
         split = config.split_version()
         filename = config.name + config.file_extension
         all_paths = [
-            join(config.environment_root, config.child_dir, split[0], filename),
-            join(config.environment_root, config.child_dir, split[1], filename),
-            join(config.environment_root, config.child_dir, split[2], filename),
-            join(config.environment_root, config.child_dir + os.sep, filename),
-            join(config.local_dir, config.child_dir, split[0], filename),
-            join(config.local_dir, config.child_dir, split[1], filename),
-            join(config.local_dir, config.child_dir, split[2], filename),
-            join(config.local_dir, config.child_dir + os.sep, filename),
-            join(config.user_root, "." + config.child_dir, split[0], filename),
-            join(config.user_root, "." + config.child_dir, split[1], filename),
-            join(config.user_root, "." + config.child_dir, split[2], filename),
-            join(config.user_root, "." + config.child_dir + os.sep, filename),
             join(config.system_root, config.child_dir, split[0], filename),
             join(config.system_root, config.child_dir, split[1], filename),
             join(config.system_root, config.child_dir, split[2], filename),
             join(config.system_root, config.child_dir + os.sep, filename),
+            join(config.user_root, "." + config.child_dir, split[0], filename),
+            join(config.user_root, "." + config.child_dir, split[1], filename),
+            join(config.user_root, "." + config.child_dir, split[2], filename),
+            join(config.user_root, "." + config.child_dir + os.sep, filename),
+            join(config.local_dir, config.child_dir, split[0], filename),
+            join(config.local_dir, config.child_dir, split[1], filename),
+            join(config.local_dir, config.child_dir, split[2], filename),
+            join(config.local_dir, config.child_dir + os.sep, filename),
+            join(config.environment_root, config.child_dir, split[0], filename),
+            join(config.environment_root, config.child_dir, split[1], filename),
+            join(config.environment_root, config.child_dir, split[2], filename),
+            join(config.environment_root, config.child_dir + os.sep, filename),
         ]
         self.assertEqual(config.files(validate=False), all_paths)
 


### PR DESCRIPTION
Since the configuration loader will load all configuration files it
finds, as opposed to just the first, and overwrite keys from
earlier-loaded files with those from files loaded later, the loading
order needs to be

less specific > more specific

In the previous from, the default shipped configuration file (agent.yml
in case of the agent) would be loaded last and overwrite all the
settings from all other files.  This would make user-configuration
completely impossible.